### PR TITLE
Fixed issue when copying files with spaces in name

### DIFF
--- a/Controller/ViewerController.php
+++ b/Controller/ViewerController.php
@@ -26,7 +26,7 @@ class ViewerController extends Controller
         }
 
         if($isPdfOutsideWebroot){
-            exec('cp '.$pdf.' '.$this->get('kernel')->getRootDir().'/../web'.$tmpPdfPath.' 2>&1', $output, $returnVal);
+            exec('cp "'.$pdf.'" '.$this->get('kernel')->getRootDir().'/../web'.$tmpPdfPath.' 2>&1', $output, $returnVal);
             if($returnVal!=0){
                 throw new \Exception('Can not copy pdf file to temporal directory: Exit='.$returnVal.' Message: '.implode(' ',$output));
             }


### PR DESCRIPTION
When a file contains space(s) in its name, the copy does not work.
This PR solves the problem.